### PR TITLE
Fix #21: High CPU usage in a small project

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -22,7 +22,6 @@ pub mod vfs_watch;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
 
 use core::Config;
 use pathext::canonicalish;

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -195,7 +195,7 @@ fn main() {
             println!("Server listening on port {}", port);
 
             loop {
-                thread::sleep(Duration::from_secs(1));
+                thread::park();
             }
         },
         ("pack", _) => {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -22,6 +22,7 @@ pub mod vfs_watch;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use core::Config;
 use pathext::canonicalish;
@@ -193,7 +194,9 @@ fn main() {
 
             println!("Server listening on port {}", port);
 
-            loop {}
+            loop {
+                thread::sleep(Duration::from_secs(1));
+            }
         },
         ("pack", _) => {
             eprintln!("'rojo pack' is not yet implemented!");

--- a/src/vfs_watch.rs
+++ b/src/vfs_watch.rs
@@ -92,6 +92,8 @@ impl VfsWatcher {
             }
         }
 
-        loop {}
+        loop {
+            thread::sleep(Duration::from_secs(1));
+        }
     }
 }

--- a/src/vfs_watch.rs
+++ b/src/vfs_watch.rs
@@ -93,7 +93,7 @@ impl VfsWatcher {
         }
 
         loop {
-            thread::sleep(Duration::from_secs(1));
+            thread::park();
         }
     }
 }


### PR DESCRIPTION
The infinite loops that are keeping the threads alive are what really was killing CPU usage. Sleeping for 100 ms seems to work. Not sure how exactly rust async works right now, so this may cause delay of up to 1 second before polling, but filesystem already uses that delay.

Preferably, the webserver also just uses the main thread, instead of creating its own. Busy polling is still bad. 