### PR TITLE
Fix issue w/ existing files not being updated in imfs

### DIFF
--- a/server/src/imfs.rs
+++ b/server/src/imfs.rs
@@ -208,7 +208,6 @@ impl Imfs {
                     if self.items.contains_key(&next_path) {
                         current_path = next_path;
                     } else {
-                        self.read_from_disk(&current_path)?;
                         break;
                     }
                 },
@@ -216,7 +215,7 @@ impl Imfs {
             }
         }
 
-        Ok(())
+        self.read_from_disk(&current_path)
     }
 
     fn read_from_disk(&mut self, path: &Path) -> Result<(), FsError> {


### PR DESCRIPTION
Fixes an issue with some recent refactors that caused the imfs to short circuit out of updating the contents of any particular file it already knew about. Only changes higher in the file tree would actually trigger the update.

To do:
[ ] Add regression test