### PR TITLE
Rewrite CSV conversion to dodge Serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Changed `rojo build` to use buffered I/O, which can make it up to 2x faster in some cases.
     * Building [*Road Not Taken*](https://github.com/LPGhatguy/roads) to an `rbxlx` file dropped from 150ms to 70ms on my machine
 * Fixed `LocalizationTable` instances being made from `csv` files not supporting empty rows or columns. ([#149](https://github.com/LPGhatguy/rojo/pull/149))
+* Fixed CSV files with entries that parse as numbers causing Rojo to panic ([#152](https://github.com/LPGhatguy/rojo/pull/152))
+* Improved error messages when malformed CSV files are found in a Rojo project
 
 ## [0.5.0 Alpha 8](https://github.com/LPGhatguy/rojo/releases/tag/v0.5.0-alpha.8) (March 29, 2019)
 * Added support for a bunch of new types when dealing with XML model/place files:

--- a/test-projects/localization/expected-snapshot.json
+++ b/test-projects/localization/expected-snapshot.json
@@ -20,6 +20,22 @@
       }
     },
     {
+      "name": "integers-bug-145",
+      "class_name": "LocalizationTable",
+      "properties": {
+        "Contents": {
+          "Type": "String",
+          "Value": "[{\"key\":\"Count\",\"example\":\"A number demonstrating issue 145\",\"source\":\"3\",\"values\":{\"es\":\"7\"}}]"
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": false,
+        "source_path": "src/integers-bug-145.csv",
+        "project_definition": null
+      }
+    },
+    {
       "name": "normal",
       "class_name": "LocalizationTable",
       "properties": {

--- a/test-projects/localization/src/integers-bug-145.csv
+++ b/test-projects/localization/src/integers-bug-145.csv
@@ -1,0 +1,2 @@
+Key,Source,Context,Example,es
+Count,3,,A number demonstrating issue 145,7


### PR DESCRIPTION
Fixes #145.

After filing a bug on the csv crate (https://github.com/BurntSushi/rust-csv/issues/151) it became pretty clear that there isn't really a way for Serde to losslessly decode the localization format Roblox expects for me.

This PR rewrites the CSV parser to manually trawl each record and map them into structs. I added a new regression test for #145 and made sure all existing tests continued to pass.