### PR TITLE
Support implicit values in JSON models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rojo Changelog
 
 ## [Unreleased]
+* Added support for implicit property values in JSON model files ([#154](https://github.com/LPGhatguy/rojo/pull/154))
 
 ## [0.5.0 Alpha 9](https://github.com/LPGhatguy/rojo/releases/tag/v0.5.0-alpha.9) (April 4, 2019)
 * Changed `rojo build` to use buffered I/O, which can make it up to 2x faster in some cases.

--- a/server/tests/snapshot_snapshots.rs
+++ b/server/tests/snapshot_snapshots.rs
@@ -33,6 +33,7 @@ macro_rules! generate_snapshot_tests {
 
 generate_snapshot_tests!(
     empty,
+    json_model,
     localization,
     multi_partition_game,
     nested_partitions,

--- a/test-projects/json_model/default.project.json
+++ b/test-projects/json_model/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "json_model",
+  "tree": {
+    "$path": "src"
+  }
+}

--- a/test-projects/json_model/expected-snapshot.json
+++ b/test-projects/json_model/expected-snapshot.json
@@ -1,0 +1,76 @@
+{
+  "name": "json_model",
+  "class_name": "Folder",
+  "properties": {},
+  "children": [
+    {
+      "name": "children",
+      "class_name": "Folder",
+      "properties": {},
+      "children": [
+        {
+          "name": "The Child",
+          "class_name": "StringValue",
+          "properties": {},
+          "children": [],
+          "metadata": {
+            "ignore_unknown_instances": false,
+            "source_path": null,
+            "project_definition": null
+          }
+        }
+      ],
+      "metadata": {
+        "ignore_unknown_instances": false,
+        "source_path": "src/children.model.json",
+        "project_definition": null
+      }
+    },
+    {
+      "name": "explicit",
+      "class_name": "StringValue",
+      "properties": {
+        "Value": {
+          "Type": "String",
+          "Value": "Hello, world!"
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": false,
+        "source_path": "src/explicit.model.json",
+        "project_definition": null
+      }
+    },
+    {
+      "name": "implicit",
+      "class_name": "StringValue",
+      "properties": {
+        "Value": {
+          "Type": "String",
+          "Value": "What's happenin', Earth?"
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": false,
+        "source_path": "src/implicit.model.json",
+        "project_definition": null
+      }
+    }
+  ],
+  "metadata": {
+    "ignore_unknown_instances": false,
+    "source_path": "src",
+    "project_definition": [
+      "json_model",
+      {
+        "class_name": null,
+        "children": {},
+        "properties": {},
+        "ignore_unknown_instances": null,
+        "path": "src"
+      }
+    ]
+  }
+}

--- a/test-projects/json_model/src/children.model.json
+++ b/test-projects/json_model/src/children.model.json
@@ -1,0 +1,10 @@
+{
+  "Name": "children",
+  "ClassName": "Folder",
+  "Children": [
+    {
+      "Name": "The Child",
+      "ClassName": "StringValue"
+    }
+  ]
+}

--- a/test-projects/json_model/src/explicit.model.json
+++ b/test-projects/json_model/src/explicit.model.json
@@ -1,0 +1,11 @@
+{
+  "Name": "explicit",
+  "ClassName": "StringValue",
+  "Properties": {
+    "Value": {
+      "Type": "String",
+      "Value": "Hello, world!"
+    }
+  },
+  "Children": []
+}

--- a/test-projects/json_model/src/implicit.model.json
+++ b/test-projects/json_model/src/implicit.model.json
@@ -1,0 +1,7 @@
+{
+  "Name": "implicit",
+  "ClassName": "StringValue",
+  "Properties": {
+    "Value": "What's happenin', Earth?"
+  }
+}


### PR DESCRIPTION
Closes #31. Closes #144.

This PR makes JSON model files more friendly by letting them use implicit property values.

Previously, your `.model.json` file might look like:

```json
{
  "Name": "explicit",
  "ClassName": "StringValue",
  "Properties": {
    "Value": {
      "Type": "String",
      "Value": "Hello, world!"
    }
  }
}
```

Now, for many property values, you can instead write:

```json
{
  "Name": "explicit",
  "ClassName": "StringValue",
  "Properties": {
    "Value": "Hello, world!"
  }
}
```

This change happened for project files a few releases ago, but the JSON model format wasn't updated to match.