### PR TITLE
Merge instances between filesystem and project nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 * Added support for implicit property values in JSON model files ([#154](https://github.com/LPGhatguy/rojo/pull/154))
+* Fixed minor bugs when filesystem paths defined in projects alias eachother
+* Added support for patching objects defined on the filesystem by defining an instance in your project with the same name. ([#168](https://github.com/LPGhatguy/rojo/pull/168))
 
 ## [0.5.0 Alpha 9](https://github.com/LPGhatguy/rojo/releases/tag/v0.5.0-alpha.9) (April 4, 2019)
 * Changed `rojo build` to use buffered I/O, which can make it up to 2x faster in some cases.

--- a/server/tests/snapshot_snapshots.rs
+++ b/server/tests/snapshot_snapshots.rs
@@ -33,6 +33,7 @@ macro_rules! generate_snapshot_tests {
 
 generate_snapshot_tests!(
     empty,
+    fs_project_merging,
     json_model,
     localization,
     multi_partition_game,

--- a/test-projects/fs_project_merging/default.project.json
+++ b/test-projects/fs_project_merging/default.project.json
@@ -1,0 +1,11 @@
+{
+  "name": "fs_project_merging",
+  "tree": {
+    "$path": "outer",
+
+    "inner": {
+      "$path": "outer/inner",
+      "$ignoreUnknownInstances": true
+    }
+  }
+}

--- a/test-projects/fs_project_merging/expected-snapshot.json
+++ b/test-projects/fs_project_merging/expected-snapshot.json
@@ -1,0 +1,66 @@
+{
+  "name": "fs_project_merging",
+  "class_name": "Folder",
+  "properties": {},
+  "children": [
+    {
+      "name": "inner",
+      "class_name": "Folder",
+      "properties": {},
+      "children": [
+        {
+          "name": "foo",
+          "class_name": "StringValue",
+          "properties": {
+            "Value": {
+              "Type": "String",
+              "Value": "This file has to be here for Git."
+            }
+          },
+          "children": [],
+          "metadata": {
+            "ignore_unknown_instances": false,
+            "source_path": "outer/inner/foo.txt",
+            "project_definition": null
+          }
+        }
+      ],
+      "metadata": {
+        "ignore_unknown_instances": true,
+        "source_path": "outer/inner",
+        "project_definition": [
+          "inner",
+          {
+            "class_name": null,
+            "children": {},
+            "properties": {},
+            "ignore_unknown_instances": true,
+            "path": "outer/inner"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "ignore_unknown_instances": false,
+    "source_path": "outer",
+    "project_definition": [
+      "fs_project_merging",
+      {
+        "class_name": null,
+        "children": {
+          "inner": {
+            "class_name": null,
+            "children": {},
+            "properties": {},
+            "ignore_unknown_instances": true,
+            "path": "outer/inner"
+          }
+        },
+        "properties": {},
+        "ignore_unknown_instances": null,
+        "path": "outer"
+      }
+    ]
+  }
+}

--- a/test-projects/fs_project_merging/outer/inner/foo.txt
+++ b/test-projects/fs_project_merging/outer/inner/foo.txt
@@ -1,0 +1,1 @@
+This file has to be here for Git.


### PR DESCRIPTION
Fixes #167.

This change allows users to specify project nodes that'll be applied to existing instances, like ones that come from folders or from within model files.

I added a test project (`test-projects/fs_project_merging`) that illustrates this:

```json
{
  "name": "fs_project_merging",
  "tree": {
    "$path": "outer",

    "inner": {
      "$path": "outer/inner",
      "$ignoreUnknownInstances": true
    }
  }
}
```

---

Before this PR:

![image](https://user-images.githubusercontent.com/654598/57007370-f02c0e00-6b9c-11e9-9223-0423e439b82d.png)

---

After this PR:

![image](https://user-images.githubusercontent.com/654598/57007369-e73b3c80-6b9c-11e9-9786-c3da1802ce18.png)
