### PR TITLE
Support for .meta.json files other than init

### DIFF
--- a/test-projects/meta_files/expected-snapshot.json
+++ b/test-projects/meta_files/expected-snapshot.json
@@ -23,13 +23,13 @@
       "name": "DisableMe",
       "class_name": "Script",
       "properties": {
-        "Source": {
-          "Type": "String",
-          "Value": ""
-        },
         "Disabled": {
           "Type": "Bool",
           "Value": true
+        },
+        "Source": {
+          "Type": "String",
+          "Value": ""
         }
       },
       "children": [],
@@ -43,13 +43,13 @@
       "name": "LocalizationTable",
       "class_name": "LocalizationTable",
       "properties": {
-        "SourceLocaleId": {
-          "Type": "String",
-          "Value": "es"
-        },
         "Contents": {
           "Type": "String",
           "Value": "[{\"key\":\"Doge\",\"example\":\"A funny dog\",\"source\":\"Perro!\",\"values\":{\"en\":\"Doge!\"}}]"
+        },
+        "SourceLocaleId": {
+          "Type": "String",
+          "Value": "es"
         }
       },
       "children": [],
@@ -60,22 +60,54 @@
       }
     },
     {
+      "name": "RobloxInstance",
+      "class_name": "Folder",
+      "properties": {
+        "Tags": {
+          "Type": "BinaryString",
+          "Value": ""
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": true,
+        "source_path": null,
+        "project_definition": null
+      }
+    },
+    {
       "name": "Script",
       "class_name": "Script",
       "properties": {
-        "Source": {
-          "Type": "String",
-          "Value": "print(\"Hello, world\")"
-        },
         "Disabled": {
           "Type": "Bool",
           "Value": true
+        },
+        "Source": {
+          "Type": "String",
+          "Value": "print(\"Hello, world\")"
         }
       },
       "children": [],
       "metadata": {
         "ignore_unknown_instances": false,
         "source_path": "src/Script",
+        "project_definition": null
+      }
+    },
+    {
+      "name": "StringValue",
+      "class_name": "StringValue",
+      "properties": {
+        "Value": {
+          "Type": "String",
+          "Value": "I'm supposed to put funny text here, aren't I? Oh well."
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": true,
+        "source_path": "src/StringValue.txt",
         "project_definition": null
       }
     }

--- a/test-projects/meta_files/expected-snapshot.json
+++ b/test-projects/meta_files/expected-snapshot.json
@@ -20,16 +20,56 @@
       }
     },
     {
-      "name": "Script",
+      "name": "DisableMe",
       "class_name": "Script",
       "properties": {
+        "Source": {
+          "Type": "String",
+          "Value": ""
+        },
         "Disabled": {
           "Type": "Bool",
           "Value": true
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": true,
+        "source_path": "src/DisableMe.server.lua",
+        "project_definition": null
+      }
+    },
+    {
+      "name": "LocalizationTable",
+      "class_name": "LocalizationTable",
+      "properties": {
+        "SourceLocaleId": {
+          "Type": "String",
+          "Value": "es"
         },
+        "Contents": {
+          "Type": "String",
+          "Value": "[{\"key\":\"Doge\",\"example\":\"A funny dog\",\"source\":\"Perro!\",\"values\":{\"en\":\"Doge!\"}}]"
+        }
+      },
+      "children": [],
+      "metadata": {
+        "ignore_unknown_instances": false,
+        "source_path": "src/LocalizationTable.csv",
+        "project_definition": null
+      }
+    },
+    {
+      "name": "Script",
+      "class_name": "Script",
+      "properties": {
         "Source": {
           "Type": "String",
           "Value": "print(\"Hello, world\")"
+        },
+        "Disabled": {
+          "Type": "Bool",
+          "Value": true
         }
       },
       "children": [],

--- a/test-projects/meta_files/src/DisableMe.meta.json
+++ b/test-projects/meta_files/src/DisableMe.meta.json
@@ -1,0 +1,6 @@
+{
+  "ignoreUnknownInstances": true,
+  "properties": {
+    "Disabled": true
+  }
+}

--- a/test-projects/meta_files/src/LocalizationTable.csv
+++ b/test-projects/meta_files/src/LocalizationTable.csv
@@ -1,0 +1,2 @@
+Key,Source,Context,Example,en
+Doge,Perro!,,A funny dog,Doge!

--- a/test-projects/meta_files/src/LocalizationTable.meta.json
+++ b/test-projects/meta_files/src/LocalizationTable.meta.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "SourceLocaleId": "es"
+  }
+}

--- a/test-projects/meta_files/src/RobloxInstance.meta.json
+++ b/test-projects/meta_files/src/RobloxInstance.meta.json
@@ -1,0 +1,3 @@
+{
+  "ignoreUnknownInstances": true
+}

--- a/test-projects/meta_files/src/RobloxInstance.rbxmx
+++ b/test-projects/meta_files/src/RobloxInstance.rbxmx
@@ -1,0 +1,11 @@
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+	<Meta name="ExplicitAutoJoints">true</Meta>
+	<External>null</External>
+	<External>nil</External>
+	<Item class="Folder" referent="RBXFC73D3B1B4524E729A1563A276CBC702">
+		<Properties>
+			<string name="Name">Folder</string>
+			<BinaryString name="Tags"></BinaryString>
+		</Properties>
+	</Item>
+</roblox>

--- a/test-projects/meta_files/src/StringValue.meta.json
+++ b/test-projects/meta_files/src/StringValue.meta.json
@@ -1,0 +1,3 @@
+{
+  "ignoreUnknownInstances": true
+}

--- a/test-projects/meta_files/src/StringValue.txt
+++ b/test-projects/meta_files/src/StringValue.txt
@@ -1,0 +1,1 @@
+I'm supposed to put funny text here, aren't I? Oh well.


### PR DESCRIPTION
*Truly* closes #123.

`Thing.server.lua` would have a `.meta.json` of `Thing.meta.json`, as said by LPG on Discord.